### PR TITLE
Add delegate method for overriding the dismiss on click behavior

### DIFF
--- a/YCHActionSheet/YCHActionSheet.h
+++ b/YCHActionSheet/YCHActionSheet.h
@@ -53,6 +53,10 @@
 - (void)willDismissActionSheet:(YCHActionSheet *)actionSheet;
 - (void)didDismissActionSheet:(YCHActionSheet *)actionSheet;
 
+// Called when a button is clicked. Returning NO will prevent the click from dismissing the action sheet.
+// The default is YES.
+- (BOOL)actionSheet:(YCHActionSheet *)actionSheet shouldDismissForButtonAtIndex:(NSUInteger)buttonIndex sectionIndex:(NSUInteger)sectionIndex;
+
 @end
 
 /**

--- a/YCHActionSheet/YCHActionSheet.m
+++ b/YCHActionSheet/YCHActionSheet.m
@@ -416,8 +416,15 @@ typedef NS_OPTIONS(NSUInteger, YCHRectCorner) {
     {
         [self.delegate actionSheet:self clickedButtonAtIndex:button.buttonIndex sectionIndex:button.sectionIndex];
     }
-    
-    [self dismiss];
+
+	BOOL shouldDismiss = YES;
+	if ([self.delegate respondsToSelector:@selector(actionSheet:shouldDismissForButtonAtIndex:sectionIndex:)])
+	{
+		shouldDismiss = [self.delegate actionSheet:self shouldDismissForButtonAtIndex:button.buttonIndex sectionIndex:button.sectionIndex];
+	}
+
+	if (shouldDismiss)
+		[self dismiss];
 }
 
 - (void)cancelButtonWasTouched:(id)sender

--- a/YCHActionSheet/YCHActionSheet.m
+++ b/YCHActionSheet/YCHActionSheet.m
@@ -417,14 +417,14 @@ typedef NS_OPTIONS(NSUInteger, YCHRectCorner) {
         [self.delegate actionSheet:self clickedButtonAtIndex:button.buttonIndex sectionIndex:button.sectionIndex];
     }
 
-	BOOL shouldDismiss = YES;
-	if ([self.delegate respondsToSelector:@selector(actionSheet:shouldDismissForButtonAtIndex:sectionIndex:)])
+    BOOL shouldDismiss = YES;
+    if ([self.delegate respondsToSelector:@selector(actionSheet:shouldDismissForButtonAtIndex:sectionIndex:)])
 	{
-		shouldDismiss = [self.delegate actionSheet:self shouldDismissForButtonAtIndex:button.buttonIndex sectionIndex:button.sectionIndex];
-	}
+        shouldDismiss = [self.delegate actionSheet:self shouldDismissForButtonAtIndex:button.buttonIndex sectionIndex:button.sectionIndex];
+    }
 
-	if (shouldDismiss)
-		[self dismiss];
+    if (shouldDismiss)
+        [self dismiss];
 }
 
 - (void)cancelButtonWasTouched:(id)sender


### PR DESCRIPTION
This can be useful if you want to respond to a button click but don't want the action sheet to dismiss. 

For example: I have an action sheet that presents a few items for selection, but also has a refresh button, for refreshing the items.
